### PR TITLE
dernières corrections suite avis Mentor

### DIFF
--- a/cvstyle.css
+++ b/cvstyle.css
@@ -18,7 +18,7 @@ body
 {
     font-family: montserratregular, "Times New Roman", Arial, verdana, sans-serif;
     color: #455A64;
-    font-size: 1rem;
+    font-size: 1em;
     margin: 0;
     padding: 0;
 }
@@ -41,14 +41,30 @@ span
 
 h1
 {
-    font-size: 3rem;
+    font-size: 3em;
+}
+
+@media screen and (max-width: 430px)
+{
+    h1
+    {
+      font-size: 2em;
+    }
 }
 
 h2
 {
-    font-size: 1.5rem;
+    font-size: 1.5em;
     font-weight: bold;
     margin-left: 4px;
+}
+
+@media screen and (max-width: 430px)
+{
+    h2
+    {
+        margin-left: 2px;
+    }
 }
 
 h1, h2, .date
@@ -58,7 +74,7 @@ h1, h2, .date
 
 h3
 {
-    font-size: 1.7rem;
+    font-size: 1.7em;
     font-weight: bold;
     color: black;
     border-bottom: solid 2px #CDDC39;
@@ -67,16 +83,24 @@ h3
     padding-bottom: 10px;
 }
 
+@media screen and (max-width: 360px)
+{
+    h3
+    {
+        font-size: 1.5em;
+    }
+}
+
 h4
 {
-    font-size: 1.2rem;
+    font-size: 1.2em;
     font-weight: bold;
 }
 
 h5
 {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 1rem;
+    font-size: 1em;
 }
 
 a
@@ -194,7 +218,6 @@ address
     border-radius: 100%;
     padding-top: 10px;
     padding-left: 10px;
-    margin-left: -25px;
 }
 
 #wcs
@@ -204,9 +227,5 @@ address
     border: solid 2px black;
     border-radius: 100%;
     object-fit: contain;
-    margin-left: -25px;
 }
-
-
-
 

--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
     <!-- Open Graph data / pour un référencement facilité sur Facebook-->
     <meta property="og:title" content="Developer web H.Dubosclard" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://github.com/HerveDubosclard/" />
+    <meta property="og:url" content="https://rvdub.github.io/CVHdub/" />
     <meta property="og:image" content="images/HerveDubosclard.jpg" />
-    <meta property="og:description" content="Curriculum vitae Herve Dubosclard" />
+    <meta property="og:description" content="Curriculum Vitae Herve Dubosclard" />
 
 
     <!-- Bootstrap CSS -->
@@ -194,7 +194,7 @@
                         </p>
 
                         <p>Site web<br />
-                            <a href="https://github.com/HerveDubosclard/" title="Mon CV responsive en ligne"
+                            <a href="https://rvdub.github.io/CVHdub/" title="Mon CV responsive en ligne"
                                 target="_blank">github.com</a>
                         </p>
 


### PR DESCRIPTION
Correction de la position des logos loisirs (suite avis Mentor)
Et relecture du code entrainant d'autres corrections sur:
unité employée pour la taille de la police,
titres de niveaux 1,2 et 3 adaptés aux très petits écrans
adresse Github pages mise à jour dans branche "development"
